### PR TITLE
fix: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -34,9 +34,9 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa  # 0.12.1
         with:
           access_token: ${{ github.token }}
 
@@ -33,9 +33,9 @@ jobs:
         run: |
           for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
           cache: "pip"
@@ -60,7 +60,7 @@ jobs:
           python vestings/exporter.py --chain-id 5 --output-directory data/allocations
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
             aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
   release:
     types: [ published ]
 
+permissions:
+  contents: read
+  actions: write
+
 env:
   REPO_NAME_ALPHANUMERIC: claiming-app-data
   STAGING_BUCKET_NAME: ${{ secrets.STAGING_BUCKET_NAME }}

--- a/.github/workflows/deploy_guardians.yml
+++ b/.github/workflows/deploy_guardians.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
 
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa  # 0.12.1
         with:
           access_token: ${{ github.token }}
 
@@ -35,9 +35,9 @@ jobs:
         run: |
           for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
           cache: "pip"
@@ -56,7 +56,7 @@ jobs:
           cd ..
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
             aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy_guardians.yml
+++ b/.github/workflows/deploy_guardians.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  actions: write
+
 env:
   REPO_NAME_ALPHANUMERIC: claiming-app-data
   STAGING_BUCKET_NAME: ${{ secrets.STAGING_BUCKET_NAME }}

--- a/.github/workflows/deploy_vestings.yml
+++ b/.github/workflows/deploy_vestings.yml
@@ -14,6 +14,10 @@ on:
           - "5"
           - "11155111"
 
+permissions:
+  contents: read
+  actions: write
+
 env:
   REPO_NAME_ALPHANUMERIC: claiming-app-data
   STAGING_BUCKET_NAME: ${{ secrets.STAGING_BUCKET_NAME }}

--- a/.github/workflows/deploy_vestings.yml
+++ b/.github/workflows/deploy_vestings.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
 
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa  # 0.12.1
         with:
           access_token: ${{ github.token }}
 
@@ -42,9 +42,9 @@ jobs:
         run: |
           for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
           cache: "pip"
@@ -59,7 +59,7 @@ jobs:
           python vestings/exporter.py --chain-id ${{ github.event.inputs.chain_id }} --output-directory data/allocations
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
             aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/generate_vesting_roots.yml
+++ b/.github/workflows/generate_vesting_roots.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa  # 0.12.1
         with:
           access_token: ${{ github.token }}
 
@@ -40,9 +40,9 @@ jobs:
         run: |
           for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/generate_vesting_roots.yml
+++ b/.github/workflows/generate_vesting_roots.yml
@@ -14,6 +14,10 @@ on:
           - 5
           - 11155111
 
+permissions:
+  contents: read
+  actions: write
+
 env:
   REPO_NAME_ALPHANUMERIC: claiming-app-data
   STAGING_BUCKET_NAME: ${{ secrets.STAGING_BUCKET_NAME }}


### PR DESCRIPTION
Resolves the `actions/missing-workflow-permissions` warnings on all five workflows by adding least-privilege `permissions` blocks.

- `ci.yml`: `contents: read` for checkout (tests only).
- `deploy.yml`, `deploy_guardians.yml`, `deploy_vestings.yml`, `generate_vesting_roots.yml`: `contents: read`, `actions: write` for `styfle/cancel-workflow-action`. S3 deploys use the AWS access-key secrets, not `GITHUB_TOKEN`.
