### PR TITLE
feat: Migrate AWS credentials to OIDC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   actions: write
+  id-token: write
 
 env:
   REPO_NAME_ALPHANUMERIC: claiming-app-data
@@ -62,8 +63,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_STAGING }}
             aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       # Script to package release files

--- a/.github/workflows/deploy_guardians.yml
+++ b/.github/workflows/deploy_guardians.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   actions: write
+  id-token: write
 
 env:
   REPO_NAME_ALPHANUMERIC: claiming-app-data
@@ -58,8 +59,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_STAGING }}
             aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       # Script to deploy to staging environment

--- a/.github/workflows/deploy_vestings.yml
+++ b/.github/workflows/deploy_vestings.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: read
   actions: write
+  id-token: write
 
 env:
   REPO_NAME_ALPHANUMERIC: claiming-app-data
@@ -61,8 +62,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_STAGING }}
             aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       # Script to deploy to staging environment


### PR DESCRIPTION
- Remove static AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY from all jobs
- Add permissions 
- Add configure-aws-credentials with role-to-assume: AWS_ROLE_TO_ASSUME_STAGING directly in pr, deploy, and release jobs
Part of [INFSEC-1135](https://linear.app/safe-global/issue/INFSEC-1135/migrate-github-actions-secrets-to-oidc).